### PR TITLE
Fix version conflicts caused by PR#109

### DIFF
--- a/src/AcBlog.Server.Api/AcBlog.Server.Api.csproj
+++ b/src/AcBlog.Server.Api/AcBlog.Server.Api.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hangfire.AspNetCore" Version="1.7.17" />
-    <PackageReference Include="Hangfire.Core" Version="1.7.17" />
-    <PackageReference Include="Hangfire.SqlServer" Version="1.7.17" />
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.7.24" />
+    <PackageReference Include="Hangfire.Core" Version="1.7.24" />
+    <PackageReference Include="Hangfire.SqlServer" Version="1.7.24" />
     <PackageReference Include="Loment" Version="0.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="5.0.0" />


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Hangfire.SqlServer from 1.7.17 to 1.7.24. [(PR#109)](https://github.com/acblog/acblog/pull/109).
Hope this fix can help you.

Best regards,
sucrose